### PR TITLE
Fix/ios build workaround

### DIFF
--- a/.github/workflows/ios_build.yaml
+++ b/.github/workflows/ios_build.yaml
@@ -51,6 +51,7 @@ jobs:
           certificate-password: ${{ secrets.IOS_CERTIFICATE_PASSWORD }}
           workspace-path: ios/skirmishreactnative.xcworkspace
           scheme: skirmishreactnative
+          export-method: developer_id
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ios_build.yaml
+++ b/.github/workflows/ios_build.yaml
@@ -51,7 +51,7 @@ jobs:
           certificate-password: ${{ secrets.IOS_CERTIFICATE_PASSWORD }}
           workspace-path: ios/skirmishreactnative.xcworkspace
           scheme: skirmishreactnative
-          export-method: developer_id
+          export-method: developer-id
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ios_build.yaml
+++ b/.github/workflows/ios_build.yaml
@@ -51,7 +51,6 @@ jobs:
           certificate-password: ${{ secrets.IOS_CERTIFICATE_PASSWORD }}
           workspace-path: ios/skirmishreactnative.xcworkspace
           scheme: skirmishreactnative
-          export-method: developer-id
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -60,6 +60,31 @@ target 'skirmishreactnative' do
       # necessary for Mac Catalyst builds
       :mac_catalyst_enabled => false
     )
-    __apply_Xcode_12_5_M1_post_install_workaround(installer)
+    #__apply_Xcode_12_5_M1_post_install_workaround(installer)
+    # !!!!!!!
+    # Modified version of the __apply_Xcode_12_5_M1_post_install_workaround function to set the minimum ios
+    # version to 12.4 instead of 11.0
+    # !!!!!!!
+    # Flipper podspecs are still targeting an older iOS deployment target, and may cause an error like:
+    #   "error: thread-local storage is not supported for the current target"
+    # The most reliable known workaround is to bump iOS deployment target to match react-native (iOS 11 now).
+    installer.pods_project.targets.each do |target|
+      target.build_configurations.each do |config|
+        # ensure IPHONEOS_DEPLOYMENT_TARGET is at least 11.0
+        deployment_target = config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'].to_f
+        should_upgrade = deployment_target < 12.4 && deployment_target != 0.0
+        if should_upgrade
+          config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '12.4'
+        end
+      end
+    end
+
+    # But... doing so caused another issue in Flipper:
+    #   "Time.h:52:17: error: typedef redefinition with different types"
+    # We need to make a patch to RCT-Folly - remove the `__IPHONE_OS_VERSION_MIN_REQUIRED` check.
+    # See https://github.com/facebook/flipper/issues/834 for more details.
+    time_header = "#{Pod::Config.instance.installation_root.to_s}/Pods/RCT-Folly/folly/portability/Time.h"
+    `sed -i -e  $'s/ && (__IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_10_0)//' '#{time_header}'`
+
   end
 end

--- a/ios/skirmishreactnative.xcodeproj/project.pbxproj
+++ b/ios/skirmishreactnative.xcodeproj/project.pbxproj
@@ -27,22 +27,6 @@
 		41D059F0297DDA9E004CDC76 /* EvilIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 41D059D2297DDA9E004CDC76 /* EvilIcons.ttf */; };
 		41D059F2297DDA9E004CDC76 /* SimpleLineIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 41D059D3297DDA9E004CDC76 /* SimpleLineIcons.ttf */; };
 		41D059F4297DDA9E004CDC76 /* MaterialIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 41D059D4297DDA9E004CDC76 /* MaterialIcons.ttf */; };
-		41D059F5297DDFA2004CDC76 /* Fontisto.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 41D059C5297DDA9E004CDC76 /* Fontisto.ttf */; };
-		41D059F6297DDFA2004CDC76 /* Octicons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 41D059C6297DDA9E004CDC76 /* Octicons.ttf */; };
-		41D059F7297DDFA2004CDC76 /* Feather.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 41D059C7297DDA9E004CDC76 /* Feather.ttf */; };
-		41D059F8297DDFA2004CDC76 /* Entypo.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 41D059C8297DDA9E004CDC76 /* Entypo.ttf */; };
-		41D059F9297DDFA2004CDC76 /* FontAwesome5_Brands.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 41D059C9297DDA9E004CDC76 /* FontAwesome5_Brands.ttf */; };
-		41D059FA297DDFA2004CDC76 /* MaterialCommunityIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 41D059CA297DDA9E004CDC76 /* MaterialCommunityIcons.ttf */; };
-		41D059FB297DDFA2004CDC76 /* AntDesign.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 41D059CB297DDA9E004CDC76 /* AntDesign.ttf */; };
-		41D059FC297DDFA2004CDC76 /* Foundation.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 41D059CC297DDA9E004CDC76 /* Foundation.ttf */; };
-		41D059FD297DDFA2004CDC76 /* Ionicons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 41D059CD297DDA9E004CDC76 /* Ionicons.ttf */; };
-		41D059FE297DDFA2004CDC76 /* FontAwesome5_Solid.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 41D059CE297DDA9E004CDC76 /* FontAwesome5_Solid.ttf */; };
-		41D059FF297DDFA2004CDC76 /* FontAwesome5_Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 41D059CF297DDA9E004CDC76 /* FontAwesome5_Regular.ttf */; };
-		41D05A00297DDFA2004CDC76 /* FontAwesome.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 41D059D0297DDA9E004CDC76 /* FontAwesome.ttf */; };
-		41D05A01297DDFA2004CDC76 /* Zocial.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 41D059D1297DDA9E004CDC76 /* Zocial.ttf */; };
-		41D05A02297DDFA2004CDC76 /* EvilIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 41D059D2297DDA9E004CDC76 /* EvilIcons.ttf */; };
-		41D05A03297DDFA2004CDC76 /* SimpleLineIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 41D059D3297DDA9E004CDC76 /* SimpleLineIcons.ttf */; };
-		41D05A04297DDFA2004CDC76 /* MaterialIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 41D059D4297DDA9E004CDC76 /* MaterialIcons.ttf */; };
 		4AAAC163593AFD0A900BCB64 /* libPods-skirmishreactnative-skirmishreactnativeTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B5C1AA416B611A036D95E3AE /* libPods-skirmishreactnative-skirmishreactnativeTests.a */; };
 		718359A2AB65A49C64EDDBD1 /* libPods-skirmishreactnative.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4002566F8A40CBCA42992B5D /* libPods-skirmishreactnative.a */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
@@ -330,22 +314,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				41D059F5297DDFA2004CDC76 /* Fontisto.ttf in Resources */,
-				41D059F6297DDFA2004CDC76 /* Octicons.ttf in Resources */,
-				41D059F7297DDFA2004CDC76 /* Feather.ttf in Resources */,
-				41D059F8297DDFA2004CDC76 /* Entypo.ttf in Resources */,
-				41D059F9297DDFA2004CDC76 /* FontAwesome5_Brands.ttf in Resources */,
-				41D059FA297DDFA2004CDC76 /* MaterialCommunityIcons.ttf in Resources */,
-				41D059FB297DDFA2004CDC76 /* AntDesign.ttf in Resources */,
-				41D059FC297DDFA2004CDC76 /* Foundation.ttf in Resources */,
-				41D059FD297DDFA2004CDC76 /* Ionicons.ttf in Resources */,
-				41D059FE297DDFA2004CDC76 /* FontAwesome5_Solid.ttf in Resources */,
-				41D059FF297DDFA2004CDC76 /* FontAwesome5_Regular.ttf in Resources */,
-				41D05A00297DDFA2004CDC76 /* FontAwesome.ttf in Resources */,
-				41D05A01297DDFA2004CDC76 /* Zocial.ttf in Resources */,
-				41D05A02297DDFA2004CDC76 /* EvilIcons.ttf in Resources */,
-				41D05A03297DDFA2004CDC76 /* SimpleLineIcons.ttf in Resources */,
-				41D05A04297DDFA2004CDC76 /* MaterialIcons.ttf in Resources */,
 				81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */,
 				13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */,
 			);


### PR DESCRIPTION
Fixed the ability to build local by:
- Removing the duplicate font file resources
- Modifying the already applied workaround in Podfile to use a more recent iOS deployment target

I **guess** the problem is that the min version required set by the existing workaround isn't new enough to satisfy all dependencies (otherwise a file called "FBReactNativeSpec.h" doesn't build because it requires a value attribute which was introduced in iOS 12.0). So I copied the source of the workaround function directly to our Podfile and modified it to use iOS 12.4. I found some solutions that suggest to modify a file generated by Pod (therefore this file isn't in this repo / ios/Pods/Pods.xcodeproj/project.pbxproj), but my way to modify the workaround function directly generates this file in the way it should be.

I don't know if there is a better solution to this problem, but if not I would suggest to keep an eye on the issue that is resolved by this workaround (https://github.com/facebook/react-native/issues/31480#issuecomment-902912841) to remove our modified workaround when the underlying issue is fixed.